### PR TITLE
chore(ci): add republish-image workflow (fix broken keycloak-plugins image)

### DIFF
--- a/.github/workflows/republish-image.yml
+++ b/.github/workflows/republish-image.yml
@@ -1,0 +1,66 @@
+name: Republish Docker image
+
+# Manually rebuild and re-push an already-released image to GHCR.
+# Use case: the published multi-arch image became corrupt/unpullable
+# (e.g. platform manifests garbage-collected) and needs regenerating
+# without cutting a new release.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Released version to rebuild & republish (e.g. 0.2.0). Must have a matching v<version> git tag."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  republish:
+    name: Rebuild & republish ${{ inputs.version }}
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_ACTOR: hyperledger-bot
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Git checkout (release tag)
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ inputs.version }}
+
+      - name: Setup Java and Scala
+        uses: olafurpg/setup-scala@v14
+        with:
+          java-version: openjdk@1.17
+
+      - name: Cache sbt
+        uses: coursier/cache-action@v6.4
+
+      - name: Build plugin jar
+        run: sbt "oid4vciPlugin / Compile / packageBin"
+
+      - name: Verify jar present for Dockerfile-ci
+        run: ls -la target/*.jar
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ env.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push multi-arch image
+        run: |
+          docker buildx build \
+            --platform=linux/arm64,linux/amd64 \
+            --provenance=false --sbom=false \
+            -f Dockerfile-ci \
+            --push \
+            -t ghcr.io/hyperledger/identus-keycloak-plugins:${{ inputs.version }} .


### PR DESCRIPTION
## Why

The published Docker image **`ghcr.io/hyperledger/identus-keycloak-plugins:0.2.0` is broken on GHCR** — it cannot be pulled:

\`\`\`
$ docker pull ghcr.io/hyperledger/identus-keycloak-plugins:0.2.0
failed to copy: ... manifests/sha256:32aa9fd5... not found: not found
\`\`\`

The tag's index exists, but **every platform manifest it references returns HTTP 404** (amd64 + arm64, all three published tags: \`0.2.0\`, \`0.1.0\`, \`0.1.0-snapshot.test.1\`). The version metadata shows the image was last updated 2024-07-03 yet broke mid-July 2026 — so the manifest blobs were **garbage-collected**, not lost to a botched re-push. The package is orphaned under the legacy \`ghcr.io/hyperledger/\` namespace (this repo is \`hyperledger-identus/keycloak-plugins\`), which is the most plausible GC trigger.

This is **blocking every PR on [hyperledger-identus/cloud-agent](https://github.com/hyperledger-identus/cloud-agent)** — its integration tests pull this image for the OID4VCI scenarios:
\`\`\`
tc.docker -  keycloak Pulling
tc.docker -  manifest unknown
IntegrationTestsRunner > classMethod FAILED
\`\`\`

## What this adds

A manual \`workflow_dispatch\` workflow (\`republish-image.yml\`) that rebuilds and re-pushes an already-released image **without cutting a new release**:
- checks out the \`v<version>\` tag,
- rebuilds the plugin jar (\`sbt "oid4vciPlugin / Compile / packageBin"\`),
- pushes a clean multi-arch image with \`--provenance=false\` (no attestation manifests).

## How to use

After merge, run it from the Actions UI (or \`gh workflow run republish-image.yml -f version=0.2.0\`) to restore \`0.2.0\`. Then verify:

\`\`\`bash
docker pull ghcr.io/hyperledger/identus-keycloak-plugins:0.2.0   # should succeed
\`\`\`

## Caveat

This republishes to the **same orphaned namespace**, so if the GC is periodic the manifests could disappear again. If that happens, the durable fix is to publish under the repo-linked namespace \`ghcr.io/hyperledger-identus/keycloak-plugins\` (update \`release.yml\` + the cloud-agent image reference) — that package is auto-linked to this repo and won't be orphaned. Happy to follow up with that if needed.

## Notes for reviewer
- I (the author of this PR) couldn't GPG-sign the commit from my environment, but \`main\` requires signed commits — merging needs to happen via a setup that can sign. Triggering the workflow afterward needs no signing.
- This only adds a workflow file; no source/runtime change.