### PR TITLE
fix(ci): publish docker image under hyperledger-identus namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ the Identus cloud agent stack.
 ```yaml
 services:
   keycloak-oid4vci-issuer:
-    image: ghcr.io/hyperledger/identus-keycloak-plugins:0.1.0
+    image: ghcr.io/hyperledger-identus/keycloak-plugins:0.2.1
     ports:
       - "9980:8080"
     command:
@@ -55,7 +55,7 @@ The image contains plugin JARs in the `/opt/keycloak/providers` directory
 Example `Dockerfile`
 
 ```
-FROM ghcr.io/hyperledger/identus-keycloak-plugins:0.1.0 AS dist
+FROM ghcr.io/hyperledger-identus/keycloak-plugins:0.2.1 AS dist
 
 FROM quay.io/keycloak/keycloak:23.0.7
 COPY --from=dist /opt/keycloak/providers/<PLUGIN_FILE>.jar /opt/keycloak/providers/<PLUGIN_FILE>.jar

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
       [
         "@semantic-release/exec",
         {
-          "prepareCmd": "docker buildx build --platform=linux/arm64,linux/amd64 -f Dockerfile-ci --push -t ghcr.io/hyperledger/identus-keycloak-plugins:${nextRelease.version} ."
+          "prepareCmd": "docker buildx build --platform=linux/arm64,linux/amd64 -f Dockerfile-ci --push -t ghcr.io/hyperledger-identus/keycloak-plugins:${nextRelease.version} ."
         }
       ],
       [


### PR DESCRIPTION
## Why

`ghcr.io/hyperledger/identus-keycloak-plugins` is **broken and can't be pulled** — its tag index exists but every platform manifest it references returns HTTP 404:

\`\`\`
$ docker pull ghcr.io/hyperledger/identus-keycloak-plugins:0.2.0
failed to copy: ... manifests/sha256:32aa9fd5... not found: not found
\`\`\`

Root cause: the package is **orphaned**. The Packages API returns \`"repo": null\` — it lives under the legacy \`hyperledger\` org and is **not linked to this repository** (\`hyperledger-identus/keycloak-plugins\`), so GHCR garbage-collected its image blobs (all 3 tags affected). This is blocking every PR on [hyperledger-identus/cloud-agent](https://github.com/hyperledger-identus/cloud-agent) (its integration tests pull this image).

## Fix

Publish under the **repo-linked namespace** \`ghcr.io/hyperledger-identus/keycloak-plugins\`. Because the package name matches this repo, GitHub auto-links it → no orphaning → no future GC. The change is the semantic-release \`prepareCmd\` buildx push target in \`package.json\`. README examples updated too.

Committed as \`fix:\` so the next semantic-release run cuts a patch release (**0.2.1**) and publishes a fresh, working image to the new namespace.

## Release flow (after merge)

\`release.yml\` only runs on \`workflow_dispatch\`/\`workflow_call\` (not on push), so after merge:

1. Trigger the release workflow → semantic-release cuts \`0.2.1\` and pushes \`ghcr.io/hyperledger-identus/keycloak-plugins:0.2.1\`.
2. **Set the new package visibility to public** (newly created packages default to private). Until this is done, the cloud-agent CI (anonymous pull) cannot fetch it. I'll attempt this via the API once the package exists; if my role lacks it, an org/package admin needs to flip it.
3. Verify \`docker pull ghcr.io/hyperledger-identus/keycloak-plugins:0.2.1\` works.
4. Update cloud-agent's image references to the new namespace + \`0.2.1\` (separate PR over there, once the image exists).

## Notes for reviewer
- \`main\` requires signed commits; I couldn't GPG-sign from my environment, so the merge needs to go through a setup that can sign.
- Scoped to the Docker image namespace. The \`build.sbt\` \`githubOwner\`/\`githubRepository\` (Maven package publishing) and README badge URLs (old \`github.com/hyperledger/\` links) are separate pre-existing concerns, left untouched.