### PR TITLE
fix(build): publish Maven artifacts under hyperledger-identus namespace

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ val V = new {
 }
 
 lazy val commonSettings = Seq(
-  githubOwner := "hyperledger",
-  githubRepository := "identus-keycloak-plugins"
+  githubOwner := "hyperledger-identus",
+  githubRepository := "keycloak-plugins"
 )
 
 lazy val oid4vciPlugin = (project in file("."))


### PR DESCRIPTION
## Why

Follow-up to #18 (which migrated the **Docker** image namespace). The first release run after #18 ([run 30343777327](https://github.com/hyperledger-identus/keycloak-plugins/actions/runs/30343777327)) failed — semantic-release computed \`0.2.1\` correctly, but \`sbt release\`'s \`publishArtifacts\` step 404'd while publishing the jar+POM:

\`\`\`
[publish] java.io.FileNotFoundException:
  https://maven.pkg.github.com/hyperledger/identus-keycloak-plugins/.../0.2.1/identus-keycloak-oid4vci-0.2.1.pom
\`\`\`

`sbt-github-packages` publishes to \`maven.pkg.github.com/<githubOwner>/<githubRepository>\`, and those were still the legacy \`hyperledger\`/\`identus-keycloak-plugins\` — the **same orphaned namespace** as the Docker image.

## Fix

Point \`githubOwner\`/\`githubRepository\` at the current repo (\`hyperledger-identus\`/\`keycloak-plugins\`), so the Maven publish — and the Docker image push that follows it in the same release — can complete.

No release/tag was created by the failed run (semantic-release is transactional; \`version.sbt\` is still \`0.2.0-SNAPSHOT\`), so re-running \`release.yml\` after this merge will still cut **0.2.1**.

## Notes for reviewer
- Same signed-commit requirement on \`main\` — merge needs a signing setup.
- Dependency resolution is unaffected: all deps are \`org.keycloak:*\` from Maven Central; the GitHub Packages resolver is only a fallback.
- README badge URLs (lines 3–4) and the Maven-packages doc link (line 75) still point at the old \`github.com/hyperledger/\` paths — pre-existing cosmetic issues, left for a separate doc cleanup.