### PR TITLE
chore(build): stop publishing Maven artifacts; release only the Docker image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,13 +6,7 @@ val V = new {
   val keycloak = "23.0.7"
 }
 
-lazy val commonSettings = Seq(
-  githubOwner := "hyperledger",
-  githubRepository := "identus-keycloak-plugins"
-)
-
 lazy val oid4vciPlugin = (project in file("."))
-  .settings(commonSettings)
   .settings(
     name := "identus-keycloak-oid4vci",
     libraryDependencies ++= Seq(
@@ -40,6 +34,5 @@ releaseProcess := Seq[ReleaseStep](
   runTest,
   setReleaseVersion,
   ReleaseStep(releaseStepTask(oid4vciPlugin / Compile / packageBin)),
-  publishArtifacts,
   setNextVersion
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,1 @@
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
-addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.3")


### PR DESCRIPTION
## Why

Following the namespace-consistency check: the plugin jar published to GitHub Packages has **no Maven consumer anywhere in the Identus workspace** — it's consumed only via the Docker image (which \`COPY\`s it from \`target/\`). Publishing it only caused problems:

- the \`sbt-github-packages\` target (\`maven.pkg.github.com/hyperledger/identus-keycloak-plugins\`) was orphaned from the repo and **404'd**, aborting the release before the Docker image push ([run 30343777327](https://github.com/hyperledger-identus/keycloak-plugins/actions/runs/30343777327));
- GitHub Packages is inconsistent with the workspace convention, where libraries (apollo, vdr, mediator) publish to Maven Central under \`org.hyperledger.identus\`.

## Change

Drop the Maven-publish plumbing entirely:
- remove \`publishArtifacts\` from the release process;
- remove the now-unused \`commonSettings\` (\`githubOwner\`/\`githubRepository\`);
- remove the \`sbt-github-packages\` plugin.

The jar is still built (\`packageBin\` stays in the release process) so \`Dockerfile-ci\`'s \`COPY ./target/*.jar\` still works — only the Maven publish step is gone. After this, the release just: builds the jar → builds & pushes the Docker image to \`ghcr.io/hyperledger-identus/keycloak-plugins\` (from #18) → cuts the tag.

## Release flow (after merge)

Re-trigger \`release.yml\` → semantic-release cuts **0.2.1** (#18's \`fix:\` commit is already on \`main\`) and publishes only the Docker image. Then set the new GHCR package public, verify \`docker pull\`, and bump cloud-agent's image reference.

## Notes for reviewer
- \`main\` requires signed commits — merge needs a signing setup.
- No effect on the Docker image; the jar is still produced for it.